### PR TITLE
Support returning a CSV document instead of an HTML page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The simplest way to use the application is to deploy the version published to th
    Please note that the application will create IAM roles to query your DynamoDB usage. More specifically, the application needs to be granted the right to perform the actions `dynamodb:ListTables`, `dynamodb:DescribeTable`, and `cloudwatch:GetMetricData`. **The application will not read, change, delete, or share any of your data**.
 6. Edit the stack name if desired, and choose “Deploy”.
 7. You should be redirected to the newly created Lambda application. After the deployment finishes, you should see an endpoint in the “API endpoint” box.
-8. Click that endpoint to collect metrics about your DynamoDB usage and visualize the results on a web page. The web page displays a summary of your usage of provisioned tables, and a summary of your usage of on-demand tables, with links to Scylla Cloud pricing calculator to estimates your possible savings if you switch to ScyllaDB.
+8. Click that endpoint to collect metrics about your DynamoDB usage and visualize the results on a web page. The web page displays a summary of your usage of provisioned tables, and a summary of your usage of on-demand tables, with links to Scylla Cloud pricing calculator to estimates your possible savings if you switch to ScyllaDB. See the “Use” section below for more options.
 
 To delete the application, delete the CloudFormation stack that was created during the deployment step. Open the CloudFormation console at https://console.aws.amazon.com/cloudformation#/stacks. Find the deployed stack (for example, look for `serverlessrepo-dynamodb-pricing-comparison`), and choose “Delete”.
 
@@ -47,13 +47,36 @@ The first command will build the source of the application. The second command w
 The following output will be displayed in the outputs when the deployment is complete:
 * API Gateway endpoint URL
 
-Open that endpoint URL to collect metrics about your DynamoDB usage and visualize the results on a web page.
+Open that endpoint URL to collect metrics about your DynamoDB usage and visualize the results on a web page. See the “Use” section below for more options.
 
 To delete the application, you can use the AWS CLI. Assuming you used `dynamodb-pricing-comparison` for the stack name, you can run the following:
 
 ~~~ shell
 sam delete --stack-name dynamodb-pricing-comparison
 ~~~
+
+## Use
+
+The installation process outputs the URL of an API endpoint that you can call to collect metrics about your DynamoDB usage.
+
+The endpoint supports the following query parameter:
+
+- `format`: Accepted values are either `html` or `csv`. This parameter is optional and defaults to `html`. With `format=html`, the endpoint produces an HTML page that can be rendered by a Web browser. With `format=csv`, the endpoint produces a CSV document with the following columns:
+  - Table name
+  - Billing mode (`PAY_PER_REQUEST`, or `PROVISIONED`)
+  - Table size (bytes)
+  - Average item size (bytes)
+  - Read capacity units
+  - Write capacity units
+  - ScyllaDB cloud pricing comparison
+
+For instance, to export your DynamoDB usage into a CSV file, use the following command:
+
+~~~ bash
+curl "${API_GATEWAY_ENDPOINT_URL}?format=csv" > dynamodb-usage.csv
+~~~
+
+Where `API_GATEWAY_ENDPOINT_URL` is the URL of the API endpoint produced by the installation process.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AWS Serverless Application that analyzes your DynamoDB usage on the AWS cloud, and shows you the pricing for an equivalent usage of [ScyllaDB’s Alternator](https://resources.scylladb.com/dynamodb-replacement), which is a drop-in alternative for DynamoDB.
 
+For the sake of simplicity the usage of both on-demand and provisioned tables is expressed in read or write capacity units. In the case of provisioned tables, it corresponds to the provisioned capacity. In the case of on-demand tables, it corresponds to the average usage per second over the last 30 days.
+
 ## Install
 
 The simplest way to use the application is to deploy the version published to the AWS Serverless Application Repository. Alternatively, you can build the application from the sources and deploy it with the AWS SAM CLI.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "3.590.0",
-        "@aws-sdk/client-dynamodb": "3.590.0"
+        "@aws-sdk/client-dynamodb": "3.590.0",
+        "csv-writer": "1.6.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1231,6 +1232,11 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "private": "true",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.590.0",
-    "@aws-sdk/client-cloudwatch": "3.590.0"
+    "@aws-sdk/client-cloudwatch": "3.590.0",
+    "csv-writer": "1.6.0"
   }
 }

--- a/backend/src/render/common.mjs
+++ b/backend/src/render/common.mjs
@@ -1,0 +1,15 @@
+import {kB, TB} from "../util.mjs";
+
+/**
+ * @param {UsageSummary} table
+ * @returns {string}
+ */
+export const scyllaPricingUrl = (table) => {
+  const uri = new URL('https://www.scylladb.com/product/scylla-cloud/get-pricing?');
+  uri.searchParams.append('reads', Math.round(table.readThroughputBytes / table.averageItemSizeBytes).toString());
+  uri.searchParams.append('writes', Math.round(table.writeThroughputBytes / table.averageItemSizeBytes).toString());
+  uri.searchParams.append('itemSize', Math.round(table.averageItemSizeBytes / kB).toString());
+  uri.searchParams.append('storage', Math.round(table.sizeBytes / TB).toString());
+  uri.searchParams.append('cloudProvider', 'AWS')
+  return uri.href
+};

--- a/backend/src/render/common.mjs
+++ b/backend/src/render/common.mjs
@@ -1,15 +1,15 @@
 import {kB, TB} from "../util.mjs";
 
 /**
- * @param {UsageSummary} table
+ * @param {UsageSummary} summary
  * @returns {string}
  */
-export const scyllaPricingUrl = (table) => {
+export const scyllaPricingUrl = (summary) => {
   const uri = new URL('https://www.scylladb.com/product/scylla-cloud/get-pricing?');
-  uri.searchParams.append('reads', Math.round(table.readThroughputBytes / table.averageItemSizeBytes).toString());
-  uri.searchParams.append('writes', Math.round(table.writeThroughputBytes / table.averageItemSizeBytes).toString());
-  uri.searchParams.append('itemSize', Math.round(table.averageItemSizeBytes / kB).toString());
-  uri.searchParams.append('storage', Math.round(table.sizeBytes / TB).toString());
+  uri.searchParams.append('reads', Math.round(summary.readThroughputBytes / summary.averageItemSizeBytes).toString());
+  uri.searchParams.append('writes', Math.round(summary.writeThroughputBytes / summary.averageItemSizeBytes).toString());
+  uri.searchParams.append('itemSize', Math.round(summary.averageItemSizeBytes / kB).toString());
+  uri.searchParams.append('storage', Math.round(summary.sizeBytes / TB).toString());
   uri.searchParams.append('cloudProvider', 'AWS')
   return uri.href
 };

--- a/backend/src/render/csv.mjs
+++ b/backend/src/render/csv.mjs
@@ -1,0 +1,42 @@
+import { createArrayCsvStringifier } from 'csv-writer';
+import { BillingMode } from '@aws-sdk/client-dynamodb';
+import {scyllaPricingUrl} from "./common.mjs";
+
+/**
+ * @param {{ onDemand: Usages, provisioned: Usages }} tableCosts
+ */
+export const renderCsv = ({ onDemand, provisioned }) => {
+  const csv = createArrayCsvStringifier({
+    header: ['Table name', 'Billing mode', 'Table size', 'Average item size', 'RCU', 'WCU', 'DynamoDB comparison URL']
+  });
+  const allRecords =
+    usageRecords(provisioned, BillingMode.PROVISIONED)
+      .concat(usageRecords(onDemand, BillingMode.PAY_PER_REQUEST));
+  return csv.stringifyRecords(allRecords);
+};
+
+/**
+ * @param {Usages} usages
+ * @param {BillingMode} billingMode
+ * @return {Array<[string, string, string, string, string, string, string]>}
+ */
+const usageRecords = (usages, billingMode) =>
+  usages.tableUsages.map(table => {
+    return [
+      table.name,
+      billingMode,
+      table.sizeBytes,
+      Math.round(table.averageItemSizeBytes),
+      Math.round(table.rcu),
+      Math.round(table.wcu),
+      ''
+    ]
+  }).concat([[
+    'TOTAL',
+    billingMode,
+    usages.summary.sizeBytes,
+    Math.round(usages.summary.averageItemSizeBytes),
+    Math.round(usages.summary.readThroughputBytes / 4096),
+    Math.round(usages.summary.writeThroughputBytes / 1024),
+    scyllaPricingUrl(usages.summary)
+  ]]);

--- a/backend/src/render/html.mjs
+++ b/backend/src/render/html.mjs
@@ -1,5 +1,6 @@
-import { formatBytes, kB, TB } from './util.mjs';
-import {dynamoDB} from "./collect-dynamodb-usage.mjs";
+import {formatBytes} from '../util.mjs';
+import {dynamoDB} from "../collect-dynamodb-usage.mjs";
+import {scyllaPricingUrl} from "./common.mjs";
 
 /**
  * @param {{ onDemand: Usages, provisioned: Usages }} tableCosts
@@ -92,17 +93,3 @@ const renderUsages = usages => `
     </tr>
   </table>
 `;
-
-/**
- * @param {UsageSummary} table
- * @returns {string}
- */
-const scyllaPricingUrl = (table) => {
-  const uri = new URL('https://www.scylladb.com/product/scylla-cloud/get-pricing?');
-  uri.searchParams.append('reads', Math.round(table.readThroughputBytes / table.averageItemSizeBytes).toString());
-  uri.searchParams.append('writes', Math.round(table.writeThroughputBytes / table.averageItemSizeBytes).toString());
-  uri.searchParams.append('itemSize', Math.round(table.averageItemSizeBytes / kB).toString());
-  uri.searchParams.append('storage', Math.round(table.sizeBytes / TB).toString());
-  uri.searchParams.append('cloudProvider', 'AWS')
-  return uri.href
-};

--- a/backend/src/request.mjs
+++ b/backend/src/request.mjs
@@ -1,0 +1,15 @@
+/**
+ * @typedef {'html' | 'csv'} Format
+ */
+
+export class Request {
+  constructor() {
+    /** @type {Format} */
+    this.format = 'html';
+  }
+
+  /** @param {Format} format */
+  withFormat(format) {
+    this.format = format;
+  }
+}

--- a/events/csv-format.json
+++ b/events/csv-format.json
@@ -1,0 +1,6 @@
+{
+  "httpMethod": "GET",
+  "queryStringParameters": {
+    "format": "csv"
+  }
+}


### PR DESCRIPTION
Add a new optional `format` query parameter to the API endpoint. Valid formats are `html` (the default) or `csv`.

Fixes #3 